### PR TITLE
Allows user to set the z position of the generator, data storage method improved

### DIFF
--- a/include/MyPrimaryGeneratorMessenger.hh
+++ b/include/MyPrimaryGeneratorMessenger.hh
@@ -24,6 +24,7 @@ private:
   G4UIcommand *fSetDiscCmd;
   G4UIcommand *fSetXCmd;
   G4UIcommand *fSetYCmd;
+  G4UIcommand *fSetZCmd;
   G4UIcommand *fSetSpreadCmd;
   G4UIcommand *fSetPAzimuthCmd;
   G4UIcommand *fSetPZenithCmd;

--- a/include/event.hh
+++ b/include/event.hh
@@ -35,16 +35,22 @@ public:
   void IncrementNumDetected();
   void IncrementNumReflected();
   void IncrementNumTransmitted();
+  void RecordStep(G4int stepnum, G4int status, G4ThreeVector steppos, G4int killstatus);
 
   G4int GetNumAbsorbed() const;
   G4int GetNumDetected() const;
   G4int GetNumReflected() const;
   G4int GetNumTransmitted() const;
+  G4double GetPosX() {return xpos;}
+  G4double GetPosY() {return ypos;}
+  G4double GetPosZ() {return zpos;}
 
   void SetPhotonAngle(G4double Angle) {photonAngle = Angle;}
   void SetPosX(G4double PosX) {xpos = PosX;}
   void SetPosY(G4double PosY) {ypos = PosY;}
   void SetPosZ(G4double PosZ) {zpos = PosZ;}
+  void SetScanpointNtupleID(G4double ScanpointNtupleID) {scanpoint_ntupleId = ScanpointNtupleID;}
+  void ResetPhotNum() {photnum=0;}
   void ResetCounters();
   void SetSteppingAction(MySteppingAction* steppingAction);
 private:
@@ -56,6 +62,9 @@ private:
   G4int TotalNumAbsorbed;
   G4int TotalNumReflected;
   G4int TotalNumTransmitted;
+  G4int master_ntupleId;
+  G4int scanpoint_ntupleId;
+  G4int photnum;
 
   //  std::map<G4double, G4int> TotalNumAbsorbed;
   //  std::map<G4double, G4int> TotalNumReflected;

--- a/include/generator.hh
+++ b/include/generator.hh
@@ -35,6 +35,7 @@ public:
   void SetDiscRad(G4double discrad);
   void SetX(G4double xpos);
   void SetY(G4double ypos);
+  void SetZ(G4double zpos);
   void SetSpread(G4double spread);
 
 private:
@@ -47,6 +48,7 @@ private:
   G4double particleEnergy;
   G4double xpos = 0.0;
   G4double ypos = 0.0;
+  G4double zpos = 500.0 * mm;
   G4double spread = 0.0;
   MyPrimaryGeneratorMessenger<Laser> *fMessenger;
 };
@@ -67,6 +69,7 @@ public:
   void SetDiscRad(G4double discrad);
   void SetX(G4double xpos) {};
   void SetY(G4double ypos) {};
+  void SetZ(G4double zpos) {};
   void SetSpread(G4double spread) {};
 
 private:
@@ -95,6 +98,7 @@ public:
   void SetDiscRad(G4double discrad);
   void SetX(G4double xpos) {};
   void SetY(G4double ypos) {};
+  void SetZ(G4double zpos) {};
   void SetSpread(G4double spread) {};
 
 private:

--- a/include/run.hh
+++ b/include/run.hh
@@ -20,7 +20,7 @@ public:
   MyRunAction();
   ~MyRunAction();
 
-  void set_name_template(std::string what) { name_template = what; }
+  void set_name_template(std::string name) { name_template = name; }
 
   virtual void BeginOfRunAction(const G4Run *);
   virtual void EndOfRunAction(const G4Run *);
@@ -30,6 +30,9 @@ private:
   G4int TotalNumAbsorbed;
   G4int TotalNumReflected;
   G4int TotalNumTransmitted;
+  G4int master_ntupleId;
+  G4int scanpoint_ntupleId;
+  G4int runId;
 };
 
 #endif

--- a/src/MyPrimaryGeneratorMessenger.cc
+++ b/src/MyPrimaryGeneratorMessenger.cc
@@ -26,6 +26,9 @@ MyPrimaryGeneratorMessenger<gentype>::MyPrimaryGeneratorMessenger(gentype *gener
   fSetYCmd = new G4UIcommand("/mygenerator/SetY", this);
   fSetYCmd->SetGuidance("Set Start y in mm");
 
+  fSetZCmd = new G4UIcommand("/mygenerator/SetZ", this);
+  fSetZCmd->SetGuidance("Set Start z in mm");
+
   fSetSpreadCmd = new G4UIcommand("/mygenerator/SetSpread", this);
   fSetSpreadCmd->SetGuidance("Set Start spread in deg");
 
@@ -64,6 +67,11 @@ MyPrimaryGeneratorMessenger<gentype>::MyPrimaryGeneratorMessenger(gentype *gener
   yParam->SetDefaultValue(0);
   fSetYCmd->SetParameter(yParam);
   fSetYCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
+
+  G4UIparameter *zParam = new G4UIparameter("zpos", 'd', false);
+  zParam->SetDefaultValue(500);
+  fSetZCmd->SetParameter(zParam);
+  fSetZCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   G4UIparameter *spreadParam = new G4UIparameter("spread", 'd', false);
   spreadParam->SetDefaultValue(0);
@@ -109,6 +117,11 @@ void MyPrimaryGeneratorMessenger<gentype>::SetNewValue(G4UIcommand *command, G4S
   {
     G4double xpos = G4UIcommand::ConvertToDouble(newValue);
     fGenerator->SetY(xpos);
+  }
+  else if (command == fSetZCmd)
+  {
+    G4double zpos = G4UIcommand::ConvertToDouble(newValue);
+    fGenerator->SetZ(zpos);
   }
   else if (command == fSetSpreadCmd)
   {

--- a/src/event.cc
+++ b/src/event.cc
@@ -79,21 +79,7 @@ void MyEventAction::EndOfEventAction(const G4Event* event)
   G4cout << "No. of Photons Transmitted == " <<TotalNumTransmitted<< G4endl; 
   G4cout << "No. of Photons Detected == " << TotalNumDetected<< G4endl;
   G4cout << "Total no. of Photons == " << totalPhotons<< G4endl;
-  
   G4cout<<"Photon Angle == "<< photonAngle<<G4endl;
-  //  G4AnalysisManager *man = G4AnalysisManager::Instance();
-  man->FillNtupleDColumn(0, photonAngle);
-  man->FillNtupleIColumn(1, TotalNumAbsorbed);                                                                        
-  man->FillNtupleIColumn(2, TotalNumTransmitted);                                                                     
-  man->FillNtupleIColumn(3, TotalNumReflected);   
-  man->FillNtupleIColumn(4, xpos);   
-  man->FillNtupleIColumn(5, ypos);   
-  man->FillNtupleIColumn(6, zpos);   
-  //  man->AddNtupleRow(0);
-
-
-  man->AddNtupleRow(0);
-
 }
 
 void MyEventAction::IncrementNumAbsorbed()
@@ -142,5 +128,22 @@ void MyEventAction::ResetCounters()
   TotalNumReflected=0;
   TotalNumTransmitted=0;
   TotalNumDetected=0;
+}
 
+void MyEventAction::RecordStep(G4int stepnum, G4int status, G4ThreeVector steppos, G4int killstatus)
+// STATUS: transmission==0, reflection==1, absorption==2, anything else==3
+// KILLSTATUS: if step stops and kills track, killstatus==1, otherwise killstatus==0
+{
+  G4AnalysisManager *man = G4AnalysisManager::Instance();
+  man->FillNtupleIColumn(scanpoint_ntupleId, 0, photnum);                                                                        
+  man->FillNtupleIColumn(scanpoint_ntupleId, 1, stepnum);                                                                     
+  man->FillNtupleIColumn(scanpoint_ntupleId, 2, status);
+  man->FillNtupleDColumn(scanpoint_ntupleId, 3, steppos.getX());   
+  man->FillNtupleDColumn(scanpoint_ntupleId, 4, steppos.getY());   
+  man->FillNtupleDColumn(scanpoint_ntupleId, 5, steppos.getZ());  
+  man->AddNtupleRow(scanpoint_ntupleId);
+  if (killstatus==1)
+  {
+    photnum++;
+  }
 }

--- a/src/generator.cc
+++ b/src/generator.cc
@@ -52,6 +52,11 @@ void Laser::SetY(G4double ypos)
   this->ypos = ypos;
 }
 
+void Laser::SetZ(G4double zpos)
+{
+  this->zpos = zpos;
+}
+
 void Laser::SetSpread(G4double spread)
 {
   this->spread = spread;
@@ -64,7 +69,8 @@ void Laser::GeneratePrimaries(G4Event *anEvent)
   G4String particleName = "opticalphoton";
   G4ParticleDefinition *particle = particleTable->FindParticle(particleName);
 
-  G4ThreeVector initialPosition(xpos, ypos, 500.0 * mm);
+ // zpos was 500*mm
+  G4ThreeVector initialPosition(xpos, ypos, zpos);
   // Define the target Z coordinate
   double targetZ = 44.40 * mm;
 

--- a/src/run.cc
+++ b/src/run.cc
@@ -7,54 +7,54 @@ Author:    Mohit Gola 10th July 2023
 MyRunAction::MyRunAction()
 {
   G4AnalysisManager *man = G4AnalysisManager::Instance();
+  man->OpenFile(name_template + ".root");
 
-  //  G4AnalysisManager *man1 = G4AnalysisManager::Instance();
-  /*
-  man->CreateNtuple("Position", "Position");
-  man->CreateNtupleDColumn("PosX");
-  man->CreateNtupleDColumn("PosY");
-  man->CreateNtupleDColumn("PosZ");
-  man->FinishNtuple(0);
-  */
-  man->CreateNtuple("Photons", "Photons");
-  man->CreateNtupleDColumn("Angle");
-  man->CreateNtupleIColumn("Absorbed");
-  man->CreateNtupleIColumn("Transmitted");
-  man->CreateNtupleIColumn("Reflected");
-  man->CreateNtupleIColumn("PosX");
-  man->CreateNtupleIColumn("PosY");
-  man->CreateNtupleIColumn("PosZ");
+  G4int master_ntupleId = man->CreateNtuple("Photons_Master", "Photons_Master");
 
-  man->FinishNtuple(0);
+  man->CreateNtupleIColumn(master_ntupleId, "Scanpoint_ID");
+  man->CreateNtupleDColumn(master_ntupleId, "PosX_Initial");
+  man->CreateNtupleDColumn(master_ntupleId, "PosY_Initial");
+  man->CreateNtupleDColumn(master_ntupleId, "PosZ_Initial");
+  man->FinishNtuple(master_ntupleId);
 }
 
 MyRunAction::~MyRunAction()
 {
+  G4AnalysisManager *man = G4AnalysisManager::Instance();
+  man->CloseFile();
 }
 
 void MyRunAction::BeginOfRunAction(const G4Run *run)
 {
+  G4AnalysisManager *man = G4AnalysisManager::Instance();
+  G4RunManager *runManager = G4RunManager::GetRunManager();
+
+  std::stringstream strRunId;
+  runId = run->GetRunID();
+  strRunId << runId;
+
+  scanpoint_ntupleId = man->CreateNtuple("Photons_" + strRunId.str(), "Photons");
+  const G4UserEventAction *eventAction = runManager->GetUserEventAction();
+  MyEventAction *myEventAction = dynamic_cast<MyEventAction *>(const_cast<G4UserEventAction *>(eventAction));
+  myEventAction->SetScanpointNtupleID(scanpoint_ntupleId);
+  myEventAction->ResetPhotNum();
+
+  man->CreateNtupleIColumn(scanpoint_ntupleId, "Photon_ID");
+  man->CreateNtupleIColumn(scanpoint_ntupleId, "Step_Number");
+  man->CreateNtupleIColumn(scanpoint_ntupleId, "Step_Status");
+  man->CreateNtupleDColumn(scanpoint_ntupleId, "PosX");
+  man->CreateNtupleDColumn(scanpoint_ntupleId, "PosY");
+  man->CreateNtupleDColumn(scanpoint_ntupleId, "PosZ");
+  man->FinishNtuple(scanpoint_ntupleId);
+
   TotalNumAbsorbed = 0;
   TotalNumReflected = 0;
   TotalNumTransmitted = 0;
-
-  G4AnalysisManager *man = G4AnalysisManager::Instance();
-
-  //  G4cout<<"CHECK!!!"<<G4endl;
-  G4int runID = run->GetRunID();
-
-  std::stringstream strRunID;
-  strRunID << runID;
-
-  man->OpenFile(name_template + strRunID.str() + ".root");
 }
 
 void MyRunAction::EndOfRunAction(const G4Run *)
 {
   G4AnalysisManager *man = G4AnalysisManager::Instance();
-
-  man->Write();
-  man->CloseFile();
 
   G4RunManager *runManager = G4RunManager::GetRunManager();
   const G4UserEventAction *eventAction = runManager->GetUserEventAction();
@@ -63,7 +63,13 @@ void MyRunAction::EndOfRunAction(const G4Run *)
     MyEventAction *myEventAction = dynamic_cast<MyEventAction *>(const_cast<G4UserEventAction *>(eventAction));
     if (myEventAction)
     {
+      man->FillNtupleIColumn(master_ntupleId, 0, runId);
+      man->FillNtupleDColumn(master_ntupleId, 1, myEventAction->GetPosX());                                                                     
+      man->FillNtupleDColumn(master_ntupleId, 2, myEventAction->GetPosY());                                                                     
+      man->FillNtupleDColumn(master_ntupleId, 3, myEventAction->GetPosZ());
+      man->AddNtupleRow(master_ntupleId);
       myEventAction->ResetCounters();
     }
   }
+  man->Write();
 }


### PR DESCRIPTION
User can now set the z position of the generator by running the command /mygenerator/SetZ

Data storage method is improved
- Data for a scan now all stored in just one root file
- Root file contains one ntuple per scanpoint
- Master photon ntuple connects each ntuple to the initial conditions of its scanpoint
- Coordinates of reflection, absorption, transmission, and other (anything else causing a g4 step) are now stored, allowing user to reproduce the path of every photon simulated
